### PR TITLE
Adds letsencrypt environment variables

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -53,6 +53,9 @@
     name: '{{docker_registry_container_name}}'
     image: '{{docker_registry_container}}'
     pull: true
+    env:
+      REGISTRY_HTTP_TLS_CERTIFICATE: /etc/letsencrypt/live/{{ansible_fqdn}}/fullchain.pem
+      REGISTRY_HTTP_TLS_KEY: /etc/letsencrypt/live/{{ansible_fqdn}}/privkey.pem
     published_ports:
       - '{{docker_registry_https_port}}:5000'
     volumes:


### PR DESCRIPTION
To allow TLS to be provided by letsencrypt certificates, even after the removal of acmev1 services (and the breaking of the automatic letsencrypt functionality in the docker-registry image), this passes in the locations of the key and cert as environment variables to the docker container.
These should be made into new, user-configurable, variables, although they are not a bad default as they stand.